### PR TITLE
First libft test

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "googletest"]
+	path = deps/googletest
+	url = git@github.com:google/googletest.git

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,22 @@
+SUBPROJECTS = libft
+
+TASKS = all test clean subclean
+
+$(TASKS):
+	for dir in $(SUBPROJECTS); do $(MAKE) -C $$dir $@; done
+
+distclean: subclean
+	rm -fr deps/build deps/include deps/lib
+
+deps: googletest
+
+.PHONY: googletest
+
+googletest:
+	@cmake >/dev/null 2>&1 || { echo "Error: cmake is not installed."; exit 1; }
+	@[ -f deps/googletest/CMakeLists.txt ] || { echo "Error: No Googletest sources present. Make sure git submodules are initialized (\`git submodule update --init\`)"; exit 1; }
+	@echo "Building Googletest"
+	@cmake -S deps/googletest -B deps/build/googletest
+	@cmake --build deps/build/googletest
+	@echo "Installing Googletest to deps/"
+	@cmake --install deps/build/googletest --prefix `pwd`/deps

--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Each project includes guides and examples in the `training-materials/` folder. F
 
 - Use the `tests/` folder in each project to write your tests.
 - Run tests locally using your preferred tools or the provided Makefile.
+  - As a one-time operation, to build the dependencies (the testing framework), run `make deps`.
+  - Run `make test` to build and run your tests.
 
 ### **5. Collaborate Through GitHub**
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,11 @@ By the end of this training, you will have developed solid programming habits an
 ### **1. Clone the Repository**
 
 ```bash
-$ git clone https://github.com/yourusername/Codam-TDD-Training.git
+$ git clone --recurse-submodules https://github.com/yourusername/Codam-TDD-Training.git
 $ cd Codam-TDD-Training
 ```
+Note the project uses git submodules for dependencies.
+If you cloned without the `--recurse-submodules` option, you will need to run `git submodule update --init`.
 
 ### **2. Navigate to the Current Project**
 

--- a/deps/.gitignore
+++ b/deps/.gitignore
@@ -1,0 +1,3 @@
+/build/
+/include/
+/lib/

--- a/libft/Makefile
+++ b/libft/Makefile
@@ -1,0 +1,13 @@
+all: libft
+
+libft:
+	$(MAKE) -C src all
+
+test: libft
+	$(MAKE) -C tests test
+
+clean:
+	$(MAKE) -C src clean
+	$(MAKE) -C tests clean
+
+distclean: clean

--- a/libft/README.md
+++ b/libft/README.md
@@ -1,0 +1,1 @@
+# Project setup

--- a/libft/src/README.txt
+++ b/libft/src/README.txt
@@ -1,0 +1,3 @@
+Place your `libft` sources here.
+
+For integration with the testing framework, `make all` of your Makefile is expected to produce `libft.a`.

--- a/libft/tests/.gitignore
+++ b/libft/tests/.gitignore
@@ -1,0 +1,3 @@
+*.o
+test_libft
+

--- a/libft/tests/Makefile
+++ b/libft/tests/Makefile
@@ -1,0 +1,33 @@
+# Name of the test executable to build
+OUT = test_libft
+
+# Management of dependencies: third party (Googletest) and libft
+
+DEPS_INCLUDE_FOLDERS = ../../deps/include ../src
+DEPS_LIB_FOLDERS = ../../deps/lib ../src
+DEPS_LIBS = gmock_main gmock gtest stdc++ ft
+
+# Compiler to use
+CC = gcc
+# C++ version
+CXX_STD_VERSION = c++20
+CC_FLAGS = -Wall -Wextra -Werror
+
+SRC = $(wildcard *.cpp)
+OBJ = $(SRC:.cpp=.o)
+
+all: $(OUT)
+
+test: all
+	./$(OUT)
+
+$(OUT): $(OBJ)
+	$(CC) -o $@ $(foreach folder,$(DEPS_LIB_FOLDERS),-L$(folder)) $(foreach lib,$(DEPS_LIBS),-l$(lib)) $^
+
+%.o: %.cpp
+	$(CC) $(foreach folder,$(DEPS_INCLUDE_FOLDERS),-I$(folder)) --std=$(CXX_STD_VERSION) $(CC_FLAGS) -c -o $@ $<
+
+clean:
+	@rm -f $(OUT) $(OBJ)
+
+distclean: clean

--- a/libft/tests/test_char_functions.cpp
+++ b/libft/tests/test_char_functions.cpp
@@ -1,0 +1,17 @@
+/** @file
+ * Unit tests for the character based routines of libft, such as isalpha, isdigit, etc
+ */
+
+// Include the Google test main header file, pulling in the entire framework
+#include <gtest/gtest.h>
+
+// Include your libft's header file containing the character-based functions.
+// As the `libft` library is in C, and we're compiling the tests in C++, `extern "C"` trick is needed
+// so that C++ code can look up C symbols. (see also https://www.geeksforgeeks.org/extern-c-in-c/)
+extern "C" {
+#include <libft.h>
+}
+
+TEST(CharFunctionsTest, isalpha) {
+  EXPECT_EQ(0, ft_isalpha('0'));
+}


### PR DESCRIPTION
I drafted the first GTest test + Makefile structure. It can all be tested by adding a sample libft implementation under `libft/src`, e.g.

[sample libft impl.zip](https://github.com/user-attachments/files/18376023/sample.libft.impl.zip)

It works, but I'd appreciate an "Codam student" eye here, to make sure we're not promoting some Codam anti-patterns, and that this will integrate well with what's expected of libft implementation. How are assignments normally delivered? Would students be able to deliver straight from such repo?